### PR TITLE
Update requirements.txt to fix MeloTTS issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 txtsplit
 torch
 torchaudio
-cached_path
+botocore>=1.34.98
+cached_path>=1.6.2
 transformers>=4.43.0
 num2words==0.5.12
 unidic_lite==1.0.8


### PR DESCRIPTION
I have been experiencing the same issues reported [here](https://github.com/myshell-ai/MeloTTS/issues/118) when trying to use speech-to-speech on a macbook.
This patch implements the same solution as https://github.com/myshell-ai/MeloTTS/pull/124 (which is still open on MeloTTS)