### PR TITLE
fix: make BERT feature extraction MPS-safe

### DIFF
--- a/melo/text/bert_utils.py
+++ b/melo/text/bert_utils.py
@@ -1,0 +1,19 @@
+import sys
+
+import torch
+from transformers import AutoModel
+
+
+def resolve_bert_device(device):
+    if device in (None, "auto"):
+        if torch.cuda.is_available():
+            return "cuda"
+        if sys.platform == "darwin" and torch.backends.mps.is_available():
+            return "mps"
+        return "cpu"
+
+    return device
+
+
+def load_hidden_state_model(model_id, device):
+    return AutoModel.from_pretrained(model_id).to(device)

--- a/melo/text/chinese_bert.py
+++ b/melo/text/chinese_bert.py
@@ -1,7 +1,7 @@
 import torch
-import sys
-from transformers import AutoTokenizer, AutoModelForMaskedLM
+from transformers import AutoTokenizer
 
+from .bert_utils import load_hidden_state_model, resolve_bert_device
 
 # model_id = 'hfl/chinese-roberta-wwm-ext-large'
 local_path = "./bert/chinese-roberta-wwm-ext-large"
@@ -11,22 +11,12 @@ tokenizers = {}
 models = {}
 
 def get_bert_feature(text, word2ph, device=None, model_id='hfl/chinese-roberta-wwm-ext-large'):
+    device = resolve_bert_device(device)
     if model_id not in models:
-        models[model_id] = AutoModelForMaskedLM.from_pretrained(
-            model_id
-        ).to(device)
+        models[model_id] = load_hidden_state_model(model_id, device)
         tokenizers[model_id] = AutoTokenizer.from_pretrained(model_id)
-    model = models[model_id]
+    model = models[model_id].to(device)
     tokenizer = tokenizers[model_id]
-
-    if (
-        sys.platform == "darwin"
-        and torch.backends.mps.is_available()
-        and device == "cpu"
-    ):
-        device = "mps"
-    if not device:
-        device = "cuda"
 
     with torch.no_grad():
         inputs = tokenizer(text, return_tensors="pt")

--- a/melo/text/english_bert.py
+++ b/melo/text/english_bert.py
@@ -1,25 +1,21 @@
 import torch
-from transformers import AutoTokenizer, AutoModelForMaskedLM
-import sys
+from transformers import AutoTokenizer
+
+from .bert_utils import load_hidden_state_model, resolve_bert_device
 
 model_id = 'bert-base-uncased'
-tokenizer = AutoTokenizer.from_pretrained(model_id)
+tokenizer = None
 model = None
 
 def get_bert_feature(text, word2ph, device=None):
-    global model
-    if (
-        sys.platform == "darwin"
-        and torch.backends.mps.is_available()
-        and device == "cpu"
-    ):
-        device = "mps"
-    if not device:
-        device = "cuda"
+    global model, tokenizer
+    device = resolve_bert_device(device)
     if model is None:
-        model = AutoModelForMaskedLM.from_pretrained(model_id).to(
-            device
-        )
+        model = load_hidden_state_model(model_id, device)
+    else:
+        model = model.to(device)
+    if tokenizer is None:
+        tokenizer = AutoTokenizer.from_pretrained(model_id)
     with torch.no_grad():
         inputs = tokenizer(text, return_tensors="pt")
         for i in inputs:

--- a/melo/text/french_bert.py
+++ b/melo/text/french_bert.py
@@ -1,25 +1,21 @@
 import torch
-from transformers import AutoTokenizer, AutoModelForMaskedLM
-import sys
+from transformers import AutoTokenizer
+
+from .bert_utils import load_hidden_state_model, resolve_bert_device
 
 model_id = 'dbmdz/bert-base-french-europeana-cased'
-tokenizer = AutoTokenizer.from_pretrained(model_id)
+tokenizer = None
 model = None
 
 def get_bert_feature(text, word2ph, device=None):
-    global model
-    if (
-        sys.platform == "darwin"
-        and torch.backends.mps.is_available()
-        and device == "cpu"
-    ):
-        device = "mps"
-    if not device:
-        device = "cuda"
+    global model, tokenizer
+    device = resolve_bert_device(device)
     if model is None:
-        model = AutoModelForMaskedLM.from_pretrained(model_id).to(
-            device
-        )
+        model = load_hidden_state_model(model_id, device)
+    else:
+        model = model.to(device)
+    if tokenizer is None:
+        tokenizer = AutoTokenizer.from_pretrained(model_id)
     with torch.no_grad():
         inputs = tokenizer(text, return_tensors="pt")
         for i in inputs:

--- a/melo/text/japanese_bert.py
+++ b/melo/text/japanese_bert.py
@@ -1,6 +1,7 @@
 import torch
-from transformers import AutoTokenizer, AutoModelForMaskedLM
-import sys
+from transformers import AutoTokenizer
+
+from .bert_utils import load_hidden_state_model, resolve_bert_device
 
 
 models = {}
@@ -9,23 +10,14 @@ def get_bert_feature(text, word2ph, device=None, model_id='tohoku-nlp/bert-base-
     global model
     global tokenizer
 
-    if (
-        sys.platform == "darwin"
-        and torch.backends.mps.is_available()
-        and device == "cpu"
-    ):
-        device = "mps"
-    if not device:
-        device = "cuda"
+    device = resolve_bert_device(device)
     if model_id not in models:
-        model = AutoModelForMaskedLM.from_pretrained(model_id).to(
-            device
-        )
+        model = load_hidden_state_model(model_id, device)
         models[model_id] = model
         tokenizer = AutoTokenizer.from_pretrained(model_id)
         tokenizers[model_id] = tokenizer
     else:
-        model = models[model_id]
+        model = models[model_id].to(device)
         tokenizer = tokenizers[model_id]
 
 

--- a/melo/text/spanish_bert.py
+++ b/melo/text/spanish_bert.py
@@ -1,25 +1,21 @@
 import torch
-from transformers import AutoTokenizer, AutoModelForMaskedLM
-import sys
+from transformers import AutoTokenizer
+
+from .bert_utils import load_hidden_state_model, resolve_bert_device
 
 model_id = 'dccuchile/bert-base-spanish-wwm-uncased'
-tokenizer = AutoTokenizer.from_pretrained(model_id)
+tokenizer = None
 model = None
 
 def get_bert_feature(text, word2ph, device=None):
-    global model
-    if (
-        sys.platform == "darwin"
-        and torch.backends.mps.is_available()
-        and device == "cpu"
-    ):
-        device = "mps"
-    if not device:
-        device = "cuda"
+    global model, tokenizer
+    device = resolve_bert_device(device)
     if model is None:
-        model = AutoModelForMaskedLM.from_pretrained(model_id).to(
-            device
-        )
+        model = load_hidden_state_model(model_id, device)
+    else:
+        model = model.to(device)
+    if tokenizer is None:
+        tokenizer = AutoTokenizer.from_pretrained(model_id)
     with torch.no_grad():
         inputs = tokenizer(text, return_tensors="pt")
         for i in inputs:

--- a/test/test_api_e2e_modern_torch.py
+++ b/test/test_api_e2e_modern_torch.py
@@ -1,0 +1,142 @@
+import importlib
+import sys
+from types import ModuleType, SimpleNamespace
+
+import numpy as np
+import torch
+
+
+class FakeSynthesizer:
+    def __init__(self, *args, **kwargs):
+        self.device = "cpu"
+        self.state_dict = None
+
+    def to(self, device):
+        self.device = device
+        return self
+
+    def eval(self):
+        return self
+
+    def load_state_dict(self, state_dict, strict=True):
+        self.state_dict = state_dict
+
+    def infer(
+        self,
+        x_tst,
+        x_tst_lengths,
+        speakers,
+        tones,
+        lang_ids,
+        bert,
+        ja_bert,
+        sdp_ratio=0.2,
+        noise_scale=0.6,
+        noise_scale_w=0.8,
+        length_scale=1.0,
+    ):
+        assert x_tst.device.type == self.device
+        assert tones.device.type == self.device
+        assert lang_ids.device.type == self.device
+        assert bert.device.type == self.device
+        assert ja_bert.device.type == self.device
+        assert x_tst_lengths.device.type == self.device
+        assert speakers.device.type == self.device
+
+        audio = torch.linspace(-0.25, 0.25, 32, device=x_tst.device, dtype=torch.float32)
+        return audio.view(1, 1, -1), None
+
+
+def fake_hps():
+    return SimpleNamespace(
+        num_languages=1,
+        num_tones=1,
+        symbols=["_", "a", "b", "c"],
+        data=SimpleNamespace(
+            filter_length=8,
+            hop_length=2,
+            sampling_rate=44100,
+            n_speakers=1,
+            spk2id={"EN-Default": 0},
+        ),
+        train=SimpleNamespace(segment_size=8),
+        model={},
+    )
+
+
+def import_api_module_with_fakes():
+    utils_module = ModuleType("melo.utils")
+    utils_module.get_text_for_tts_infer = lambda text, language, hps, device, symbol_to_id: (
+        torch.zeros(1024, 3),
+        torch.zeros(768, 3),
+        torch.tensor([1, 2, 3]),
+        torch.tensor([0, 0, 0]),
+        torch.tensor([0, 0, 0]),
+    )
+
+    models_module = ModuleType("melo.models")
+    models_module.SynthesizerTrn = FakeSynthesizer
+
+    split_module = ModuleType("melo.split_utils")
+    split_module.split_sentence = lambda text, language_str: [text]
+
+    mel_processing_module = ModuleType("melo.mel_processing")
+    mel_processing_module.spectrogram_torch = lambda *args, **kwargs: None
+    mel_processing_module.spectrogram_torch_conv = lambda *args, **kwargs: None
+
+    download_utils_module = ModuleType("melo.download_utils")
+    download_utils_module.load_or_download_config = lambda *args, **kwargs: fake_hps()
+    download_utils_module.load_or_download_model = (
+        lambda *args, **kwargs: {"model": {"weights": torch.tensor([1.0])}}
+    )
+
+    originals = {}
+    fake_modules = {
+        "melo.utils": utils_module,
+        "melo.models": models_module,
+        "melo.split_utils": split_module,
+        "melo.mel_processing": mel_processing_module,
+        "melo.download_utils": download_utils_module,
+    }
+
+    for name, module in fake_modules.items():
+        originals[name] = sys.modules.get(name)
+        sys.modules[name] = module
+
+    sys.modules.pop("melo.api", None)
+    try:
+        return importlib.import_module("melo.api")
+    finally:
+        sys.modules.pop("melo.api", None)
+        for name, module in fake_modules.items():
+            original = originals[name]
+            if original is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
+
+
+def test_tts_to_file_runs_end_to_end_on_modern_torch():
+    api_module = import_api_module_with_fakes()
+
+    tts = api_module.TTS(language="EN", device="cpu")
+    audio = tts.tts_to_file("This works on current torch.", speaker_id=0, quiet=True)
+
+    assert isinstance(audio, np.ndarray)
+    assert audio.dtype == np.float32
+    assert audio.shape[0] > 0
+    assert np.isfinite(audio).all()
+
+
+def test_tts_auto_device_still_runs_with_modern_torch(monkeypatch):
+    api_module = import_api_module_with_fakes()
+
+    monkeypatch.setattr(api_module.torch.cuda, "is_available", lambda: False)
+    monkeypatch.setattr(api_module.torch.backends, "mps", SimpleNamespace(is_available=lambda: False))
+
+    tts = api_module.TTS(language="EN", device="auto")
+    audio = tts.tts_to_file("Auto device also works.", speaker_id=0, quiet=True)
+
+    assert tts.device == "cpu"
+    assert isinstance(audio, np.ndarray)
+    assert audio.dtype == np.float32

--- a/test/test_api_real_model_synthesis.py
+++ b/test/test_api_real_model_synthesis.py
@@ -1,0 +1,72 @@
+import importlib
+import os
+import sys
+import types
+
+import numpy as np
+import pytest
+
+
+def _distribute_phone(n_phone, n_word):
+    phones_per_word = [0] * n_word
+    for _ in range(n_phone):
+        min_tasks = min(phones_per_word)
+        min_index = phones_per_word.index(min_tasks)
+        phones_per_word[min_index] += 1
+    return phones_per_word
+
+
+def _stub_non_english_language_modules():
+    stubbed_names = [
+        "melo.text.chinese",
+        "melo.text.japanese",
+        "melo.text.chinese_mix",
+        "melo.text.korean",
+        "melo.text.french",
+        "melo.text.spanish",
+    ]
+    originals = {name: sys.modules.get(name) for name in stubbed_names}
+
+    for name in stubbed_names:
+        module = types.ModuleType(name)
+        module.text_normalize = lambda text: text
+        module.g2p = lambda text: (["a"], [0], [1])
+        module.get_bert_feature = lambda text, word2ph, device=None: None
+        module.distribute_phone = _distribute_phone
+        sys.modules[name] = module
+
+    return originals
+
+
+def _restore_modules(originals):
+    for name, original in originals.items():
+        if original is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = original
+
+
+@pytest.mark.skipif(
+    os.getenv("MELO_RUN_REAL_MODEL_TESTS") != "1",
+    reason="Set MELO_RUN_REAL_MODEL_TESTS=1 to run real checkpoint synthesis tests.",
+)
+def test_real_english_model_synthesizes_on_current_torch():
+    originals = _stub_non_english_language_modules()
+    sys.modules.pop("melo.api", None)
+    try:
+        api_module = importlib.import_module("melo.api")
+        tts = api_module.TTS(language="EN", device="cpu")
+        audio = tts.tts_to_file(
+            "This is a real synthesis smoke test on modern PyTorch.",
+            speaker_id=0,
+            quiet=True,
+        )
+    finally:
+        sys.modules.pop("melo.api", None)
+        _restore_modules(originals)
+
+    assert isinstance(audio, np.ndarray)
+    assert audio.dtype == np.float32
+    assert audio.shape[0] > 1000
+    assert np.isfinite(audio).all()
+    assert float(np.max(np.abs(audio))) > 0.0

--- a/test/test_bert_device_handling.py
+++ b/test/test_bert_device_handling.py
@@ -1,0 +1,57 @@
+import importlib
+from types import SimpleNamespace
+
+import torch
+
+
+class FakeBatch(dict):
+    def to(self, device):
+        return self
+
+
+class FakeTokenizer:
+    def __call__(self, text, return_tensors="pt"):
+        return FakeBatch({"input_ids": torch.tensor([[1, 2, 3]])})
+
+
+class FakeModel:
+    def __init__(self):
+        self.devices = []
+
+    def to(self, device):
+        self.devices.append(device)
+        return self
+
+    def __call__(self, **kwargs):
+        hidden = torch.ones((1, 3, 4))
+        return {"hidden_states": [hidden, hidden, hidden, hidden]}
+
+
+def test_explicit_cpu_does_not_promote_to_mps(monkeypatch):
+    module = importlib.import_module("melo.text.english_bert")
+    bert_utils = importlib.import_module("melo.text.bert_utils")
+    fake_model = FakeModel()
+
+    monkeypatch.setattr(module, "tokenizer", FakeTokenizer())
+    monkeypatch.setattr(module, "model", None)
+    monkeypatch.setattr(module, "load_hidden_state_model", lambda model_id, device: fake_model.to(device))
+    monkeypatch.setattr(bert_utils.torch.backends, "mps", SimpleNamespace(is_available=lambda: True))
+    monkeypatch.setattr(bert_utils.sys, "platform", "darwin")
+
+    features = module.get_bert_feature("abc", [1, 1, 1], device="cpu")
+
+    assert features.shape == (4, 3)
+    assert fake_model.devices == ["cpu"]
+
+
+def test_cached_model_moves_to_requested_device(monkeypatch):
+    module = importlib.import_module("melo.text.english_bert")
+    fake_model = FakeModel()
+
+    monkeypatch.setattr(module, "tokenizer", FakeTokenizer())
+    monkeypatch.setattr(module, "model", fake_model)
+
+    features = module.get_bert_feature("abc", [1, 1, 1], device="cpu")
+
+    assert features.shape == (4, 3)
+    assert fake_model.devices == ["cpu"]

--- a/test/test_bert_device_handling.py
+++ b/test/test_bert_device_handling.py
@@ -55,3 +55,28 @@ def test_cached_model_moves_to_requested_device(monkeypatch):
 
     assert features.shape == (4, 3)
     assert fake_model.devices == ["cpu"]
+
+
+def test_hidden_state_loader_uses_automodel_not_masked_lm(monkeypatch):
+    module = importlib.import_module("melo.text.bert_utils")
+    calls = []
+
+    class FakeAutoModel:
+        @staticmethod
+        def from_pretrained(model_id):
+            calls.append(("automodel", model_id))
+            return FakeModel()
+
+    class FakeAutoModelForMaskedLM:
+        @staticmethod
+        def from_pretrained(model_id):
+            raise AssertionError("Masked LM head should not be loaded for hidden-state extraction")
+
+    monkeypatch.setattr(module, "AutoModel", FakeAutoModel)
+    monkeypatch.setattr(module, "AutoModelForMaskedLM", FakeAutoModelForMaskedLM, raising=False)
+
+    model = module.load_hidden_state_model("bert-base-uncased", "cpu")
+
+    assert isinstance(model, FakeModel)
+    assert calls == [("automodel", "bert-base-uncased")]
+    assert model.devices == ["cpu"]


### PR DESCRIPTION
## Summary
- switch Melo's BERT feature extractors from AutoModelForMaskedLM to AutoModel
- honor an explicit CPU device on macOS instead of auto-promoting it to MPS
- lazily initialize tokenizers/models and add unit coverage for device handling

## Why
Melo only needs hidden states, not MLM logits. Using the masked-LM head is unnecessary work and can trigger MPS failures with modern PyTorch/Transformers on macOS. This also fixes the explicit-CPU path reported in issue #202.

## Testing
- PYTHONPATH=/home/andi/Documents/MeloTTS /home/andi/Documents/speech-to-speech/.venv/bin/pytest -q /home/andi/Documents/MeloTTS/test/test_bert_device_handling.py