### PR TITLE
fix: relax librosa version constraint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ anyascii==0.3.2
 jamo==0.4.1
 gruut[de,es,fr]==2.2.3
 g2pkk>=0.1.1
-librosa==0.9.1
+librosa>=0.11.0,<0.12
 pydub==0.25.1
 eng_to_ipa==0.0.2
 inflect==7.0.0


### PR DESCRIPTION
## Summary
- relax MeloTTS from  to 

## Why
 requires , so the current hard pin makes macOS installs unsatisfiable when  uses both packages.

## Verification
- existing Melo modern-torch tests pass with 
- real English model synthesis smoke test passed on CPU with current torch