### PR TITLE
Bump gruut to 2.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ fugashi==1.3.0
 g2p_en==2.1.0
 anyascii==0.3.2
 jamo==0.4.1
-gruut[de,es,fr]==2.2.3
+gruut[de,es,fr]==2.4.0
 g2pkk>=0.1.1
 librosa>=0.11.0,<0.12
 pydub==0.25.1


### PR DESCRIPTION
## Summary
- bump  from  to 
- pick up NumPy 2 compatible gruut dependency metadata

## Validation
- 
