### PR TITLE
Fix MeloTTS MPS decoder limit for longer utterances

### DIFF
--- a/melo/api.py
+++ b/melo/api.py
@@ -80,9 +80,39 @@ class TTS(nn.Module):
             print(" > ===========================")
         return texts
 
+    @staticmethod
+    def split_mps_clauses(texts):
+        clause_splitter = re.compile(r"([,;:])")
+        pieces = []
+
+        for text in texts:
+            parts = clause_splitter.split(text)
+            if len(parts) == 1:
+                pieces.append(text)
+                continue
+
+            current = ""
+            for part in parts:
+                if not part:
+                    continue
+                if clause_splitter.fullmatch(part):
+                    current = f"{current}{part}".strip()
+                    if current:
+                        pieces.append(current)
+                    current = ""
+                else:
+                    current = f"{current} {part}".strip() if current else part.strip()
+
+            if current:
+                pieces.append(current)
+
+        return [piece for piece in pieces if piece]
+
     def tts_to_file(self, text, speaker_id, output_path=None, sdp_ratio=0.2, noise_scale=0.6, noise_scale_w=0.8, speed=1.0, pbar=None, format=None, position=None, quiet=False,):
         language = self.language
         texts = self.split_sentences_into_pieces(text, language, quiet)
+        if self.device == "mps":
+            texts = self.split_mps_clauses(texts)
         audio_list = []
         if pbar:
             tx = pbar(texts)

--- a/melo/models.py
+++ b/melo/models.py
@@ -532,7 +532,7 @@ class Generator(torch.nn.Module):
                     xs += self.resblocks[i * self.num_kernels + j](x)
             x = xs / self.num_kernels
         x = F.leaky_relu(x)
-        x = self.conv_post(x)
+        x = modules.mps_safe_conv1d(self.conv_post, x)
         x = torch.tanh(x)
 
         return x

--- a/melo/modules.py
+++ b/melo/modules.py
@@ -14,6 +14,37 @@ from .attentions import Encoder
 LRELU_SLOPE = 0.1
 
 
+def mps_safe_conv1d(conv, x, max_chunk_length=16384):
+    """Run long Conv1d tensors in chunks on MPS to avoid the 65536-channel kernel limit."""
+    if x.device.type != "mps" or x.size(-1) <= max_chunk_length:
+        return conv(x)
+
+    kernel_size = conv.kernel_size[0]
+    dilation = conv.dilation[0]
+    stride = conv.stride[0]
+    padding = conv.padding[0]
+
+    if stride != 1:
+        return conv(x)
+
+    overlap = max(padding, dilation * (kernel_size - 1))
+    outputs = []
+    total_length = x.size(-1)
+
+    for start in range(0, total_length, max_chunk_length):
+        end = min(total_length, start + max_chunk_length)
+        chunk_start = max(0, start - overlap)
+        chunk_end = min(total_length, end + overlap)
+        chunk = x[:, :, chunk_start:chunk_end]
+        chunk_out = conv(chunk)
+
+        left_trim = start - chunk_start
+        right_trim = left_trim + (end - start)
+        outputs.append(chunk_out[:, :, left_trim:right_trim])
+
+    return torch.cat(outputs, dim=-1)
+
+
 class LayerNorm(nn.Module):
     def __init__(self, channels, eps=1e-5):
         super().__init__()
@@ -298,11 +329,11 @@ class ResBlock1(torch.nn.Module):
             xt = F.leaky_relu(x, LRELU_SLOPE)
             if x_mask is not None:
                 xt = xt * x_mask
-            xt = c1(xt)
+            xt = mps_safe_conv1d(c1, xt)
             xt = F.leaky_relu(xt, LRELU_SLOPE)
             if x_mask is not None:
                 xt = xt * x_mask
-            xt = c2(xt)
+            xt = mps_safe_conv1d(c2, xt)
             x = xt + x
         if x_mask is not None:
             x = x * x_mask
@@ -349,7 +380,7 @@ class ResBlock2(torch.nn.Module):
             xt = F.leaky_relu(x, LRELU_SLOPE)
             if x_mask is not None:
                 xt = xt * x_mask
-            xt = c(xt)
+            xt = mps_safe_conv1d(c, xt)
             x = xt + x
         if x_mask is not None:
             x = x * x_mask


### PR DESCRIPTION
## What this fixes
MeloTTS could fail on Apple Silicon with:

`NotImplementedError: Output channels > 65536 not supported at the MPS device.`

In practice this showed up in the decoder on longer English utterances such as:
`I'm just a bundle of circuits, but I'm running smoothly.`

## Changes
- chunk long decoder `Conv1d` calls on MPS so a single kernel launch does not hit the MPS limit
- apply the same MPS-safe path to the generator post-convolution
- split MPS utterances on clause punctuation (`,`, `;`, `:`) before synthesis so longer prompts do not become one oversized decoder pass

## Validation
Tested with `TTS(language="EN", device="mps")` on Apple Silicon:
- `I am fine.`
- `I'm just a bundle of circuits, but I'm running smoothly.`
- `This is a longer sentence, with two clauses, and it should still synthesize on MPS.`