### PR TITLE
Upgrade pykakasi 2.2.1 → 2.3.0 to fix pkg_resources import error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ num2words==0.5.12
 unidic_lite==1.0.8
 unidic==1.1.0
 mecab-python3==1.0.9
-pykakasi==2.2.1
+pykakasi==2.3.0
 fugashi==1.3.0
 g2p_en==2.1.0
 anyascii==0.3.2


### PR DESCRIPTION
## Summary

- Bumps `pykakasi` from `2.2.1` to `2.3.0` in `requirements.txt`

## Problem

`pykakasi 2.2.1` imports `pkg_resources` at module load time:

```python
# pykakasi/properties.py
import pkg_resources
```

`pkg_resources` is part of `setuptools` but is not reliably available in Python 3.12+ environments (e.g. when managed by `uv`), causing MeloTTS to fail on import with:

```
ModuleNotFoundError: No module named 'pkg_resources'
```

## Fix

`pykakasi 2.3.0` replaces `pkg_resources` with `importlib.resources` (stdlib), which works correctly in all Python 3.9+ environments.

## Test plan

- [ ] `python -c "from melo.api import TTS"` completes without error in a Python 3.12 venv managed by uv

🤖 Generated with [Claude Code](https://claude.com/claude-code)