### PR TITLE
Bump fugashi requirement to >=1.5.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ unidic_lite==1.0.8
 unidic==1.1.0
 mecab-python3==1.0.9
 pykakasi==2.2.1
-fugashi==1.3.0
+fugashi>=1.5.2
 g2p_en==2.1.0
 anyascii==0.3.2
 jamo==0.4.1


### PR DESCRIPTION
## Summary
- update `fugashi` dependency from `==1.3.0` to `>=1.5.2` in `requirements.txt`

## Why
- newer fugashi versions provide better wheel availability on newer Python/macOS environments
- avoids source-build friction seen with older strict pin